### PR TITLE
Update gitignore to ignore some of the files that make_img generates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ alpine-rpi-*-armhf.tar.gz
 # Don't commit LNCM variant build stuff
 lncm-box-*.tar.gz
 *.img
+
+# Don't commit work dir
+lncm-workdir/
+
+# Don't apkvol
+*.apkovl.tar.gz


### PR DESCRIPTION
Update gitignore to ignore some of the files that make_img generates so that we do not automatically commit stuff we shouldn't