### PR TITLE
lncm robustness patch

### DIFF
--- a/etc/init.d/lncm
+++ b/etc/init.d/lncm
@@ -98,16 +98,22 @@ start() {
         /bin/sed -e 's/^/root=\/dev\/mmcblk0p2 /' -i /media/${SD}p1/cmdline.txt && \
         echo "Backup old boot files" && \
         /bin/mkdir /media/mmcblk0p1/boot_backup && \
-        /bin/mv /media/mmcblk0p1/boot/* /media/mmcblk0p1/boot_backup/ && \
-        echo "Remove old boot files on fat partition" && \
-        /bin/rm -rf /media/mmcblk0p1/boot/* && \
-        echo "Copy new boot files to fat partition" && \
-        /bin/cp /media/sd/boot/* /media/mmcblk0p1/boot/ && \
-        echo "Delete new boot dir" && \
-        /bin/rm -rf /media/sd/boot && \
-        echo "Link boot to fat partition" && \
-        cd /media/sd && \
-        /bin/ln -s /media/mmcblk0p1 boot
+        /bin/mv /media/mmcblk0p1/boot/* /media/mmcblk0p1/boot_backup/
+
+        if [ -d /media/sd/boot ]; then
+            echo "Remove old boot files on fat partition" && \
+            /bin/rm -rf /media/mmcblk0p1/boot/* && \
+            echo "Copy new boot files to fat partition" && \
+            /bin/cp /media/sd/boot/* /media/mmcblk0p1/boot/ && \
+            echo "Delete new boot dir" && \
+            /bin/rm -rf /media/sd/boot && \
+            echo "Link boot to fat partition" && \
+            cd /media/sd && \
+            /bin/ln -s /media/mmcblk0p1 boot
+        else
+            echo "Uh oh! setup-desk did not put a boot directory in. Exiting"
+            exit 1
+        fi
 
         echo "Mark SD card with installed version"
         /bin/echo "$VER" > /media/${SD}p1/installed && \

--- a/etc/init.d/lncm
+++ b/etc/init.d/lncm
@@ -69,10 +69,19 @@ start() {
         /bin/mkdir /media/sd && \
         /bin/mount /media/sd
 
+        if ! [ -d /media/sd/lost+found ]; then
+            echo "Partition doesn't seem to be mounted"
+            exit 1
+        fi
+
         echo "Persist state to apkovl"
         /sbin/lbu commit && \
         echo "Install to /media/sd and apply apkovl" && \
         /sbin/setup-disk -o /media/mmcblk0p1/box.apkovl.tar.gz /media/sd
+        if ! [ -d /media/sd/etc ]; then
+            echo "Setup disk did not seem to create anything! Exiting"
+            exit 1
+        fi
 
         echo "Add FAT partition to new fstab"
         /bin/echo "/dev/mmcblk0p1 /media/mmcblk0p1 vfat defaults 0 0" >> /media/sd/etc/fstab


### PR DESCRIPTION
Add some checks in /etc/init.d/lncm to abort the process if the boot folder isn't there.
