### PR TITLE
Re-write externalip instead of appending it

### DIFF
--- a/etc/init.d/lncm-post
+++ b/etc/init.d/lncm-post
@@ -109,13 +109,13 @@ start() {
                     do 
                         echo "Tor generated directory doesn't exist yet.. waiting";
                         let CHECKTOR_HOSTNAME=CHECKTOR_HOSTNAME+1;
-                        sleep 2;
+                        sleep 1;
                     done
                    
                     # Now check to see if hostname exists
                     if [ -f /var/lib/tor/lightning/hostname ]; then
                         echo "Configuring lnd to have tor as a URI available"
-                        echo "externalip=$(cat /var/lib/tor/lightning/hostname)" >> /home/lncm/lnd/lnd.conf
+                        /bin/sed -i "s/; externalip=/externalip=$(cat /var/lib/tor/lightning/hostname)/g; " /home/lncm/lnd/lnd.conf
                     else
                         echo "Could not find the tor generated files.. exiting"
                         exit 1


### PR DESCRIPTION
The old way wasn't working.

Anyway this branch should have a fully working lncm box

```
# ./mana.sh info
bitcoind info:
{
  "version": 170100,
  "protocolversion": 70015,
  "walletversion": null,
  "balance": null,
  "blocks": 0,
  "timeoffset": 0,
  "connections": 6,
  "proxy": "",
  "difficulty": 1,
  "testnet": false,
  "keypoololdest": null,
  "keypoolsize": null,
  "paytxfee": null,
  "relayfee": 0.00001000,
  "warnings": ""
}
lnd info:
{
        "version": "0.5.1-beta commit=v0.5.1-beta-213-gfebe6cd47fd4b7d93d5373941e88046a68be25b2",
        "identity_pubkey": "03957286f74aeb75c5b3b023b9270b3bcc0851ffeb69689e7542f070a7af7aff2c",
        "alias": "LNCM BOX Default",
        "num_pending_channels": 0,
        "num_active_channels": 0,
        "num_inactive_channels": 0,
        "num_peers": 0,
        "block_height": 0,
        "block_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
        "best_header_timestamp": 2288912640,
        "synced_to_chain": false,
        "testnet": false,
        "chains": [
                "bitcoin"
        ],
        "uris": [
                "03957286f74aeb75c5b3b023b9270b3bcc0851ffeb69689e7542f070a7af7aff2c@ilgm3wt7iml4kr46kivw3wupd6fvxwsivklr5choqkvfqipmgyx4qmyd.onion:9735"
        ]
}
```