### PR TITLE
Update TLS settings to support internal docker name

### DIFF
--- a/home/lncm/lnd/lnd.conf
+++ b/home/lncm/lnd/lnd.conf
@@ -62,6 +62,21 @@ maxlogfilesize=10
 ; DANGER ZONE! Makes it impossible to restore wallets!
 ; noseedbackup=1
 
+; Control what is allowed for TLS domain names
+; Definetly allow the local hostname (within the container)
+tlsextradomain=lightningbox
+
+; Below is for scripts to write!
+; Additional Domain 1
+; 1 tlsextradomain=
+; Additional Domain 2
+; 2 tlsextradomain=
+; Additional Domain 3
+; 3 tlsextradomain=
+; Additional Domain 4
+; 4 tlsextradomain=
+; Additional Domain 5
+; 5 tlsextradomain=
 
 [Bitcoin]
 bitcoin.active=1


### PR DESCRIPTION
Update TLS settings to support internal docker name, as well as 5 other hostnames (with scriptable support).

This is to support invoicer integration 

https://github.com/lncm/pi-factory/issues/50