### PR TITLE
Enable bitcoind wallet support in configurations

### DIFF
--- a/home/lncm/bitcoin/bitcoin.conf
+++ b/home/lncm/bitcoin/bitcoin.conf
@@ -12,7 +12,6 @@ maxmempool=512
 prune=1500
 maxconnections=40
 maxuploadtarget=5000
-disablewallet=1
 
 listen=1
 bind=0.0.0.0


### PR DESCRIPTION
Bitcoind wallet support is now enabled (https://github.com/lncm/dockerfiles/commit/af73cdf5977d033166b6bbf64acc57b8675a6e66) and pushed to dockerhub  (https://github.com/lncm/dockerfiles/issues/16#issuecomment-454042650), but we still need to update the configs