### PR TITLE
Add in invoicer to docker-compose.yml

### DIFF
--- a/home/lncm/compose/docker-compose.yml
+++ b/home/lncm/compose/docker-compose.yml
@@ -40,6 +40,28 @@ services:
         networks:
             localnet:
                 ipv4_address: 172.16.88.88
+    invoicerbox:
+        image: lncm/invoicer:0.0.12
+        volumes:
+            - /media/volatile/lnd/logs:/lnd/logs
+            - /media/important/lnd:/lnd
+            - /media/important/lnd/data:/lnd/data
+            - /media/important/lnd/lnd.conf:/lnd/lnd.conf
+        ports:
+            - "8088:8080"
+        depends_on:
+            - lndbox
+        restart: on-failure
+        environment:
+            - LNDHOST=lndbox
+            - GRPC_GO_RETRY=on
+            - BTCHOST=btcbox
+            - BTCRPCUSER=RANDOMUSER
+            - BTCRPCPASS=RANDOMPASS
+            - INVOICER_HOSTPORT=invoicerbox:8080
+        networks:
+            localnet:
+                ipv4_address: 172.16.88.166
 networks:
     localnet:
         driver: bridge

--- a/home/lncm/compose/docker-compose.yml
+++ b/home/lncm/compose/docker-compose.yml
@@ -43,10 +43,7 @@ services:
     invoicerbox:
         image: lncm/invoicer:0.0.13
         volumes:
-            - /media/volatile/lnd/logs:/lnd/logs
             - /media/important/lnd:/lnd
-            - /media/important/lnd/data:/lnd/data
-            - /media/important/lnd/lnd.conf:/lnd/lnd.conf
         ports:
             - "8088:8080"
         depends_on:

--- a/home/lncm/compose/docker-compose.yml
+++ b/home/lncm/compose/docker-compose.yml
@@ -41,7 +41,7 @@ services:
             localnet:
                 ipv4_address: 172.16.88.88
     invoicerbox:
-        image: lncm/invoicer:0.0.12
+        image: lncm/invoicer:0.0.13
         volumes:
             - /media/volatile/lnd/logs:/lnd/logs
             - /media/important/lnd:/lnd


### PR DESCRIPTION
Add in invoicer with RANDOMUSER and RANDOMPASS to docker-compose.yml

Invoicer shares similar environment variables to lnd because it needs to access the tls / macaroons, although the path for this is currently /lnd (this is also configurable with another environment variable)

## List of environment variables 

Reference: https://github.com/lncm/dockerfiles/blob/5bd48c2fd2001d75d2dd59f4e71706ee605d9784/invoicer/entrypoint-invoicer.sh#L43

```
/bin/invoicer -ln-client=$LNCLIENT \
    -lnd-host=$LNDHOST \
    -lnd-port=$LNDPORT \
    -port=$PORT \
    -lnd-invoice=$INVOICEMACAROON \
    -lnd-readonly=$READONLYMACAROON \
    -lnd-tls=$LNDTLSFILE \
    -bitcoind-host=$BTCHOST \
    -bitcoind-user=$BTCRPCUSER \
    -bitcoind-pass=$BTCRPCPASS \
    -bitcoind-port=$BTCRPCPORT \
    -static-dir=$STATICDIR
```