### PR TITLE
Enable save password for create wallet script by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ machine-id
 /authorized_keys.automatic
 # For importing seeds
 home/lncm/seed.txt
-home/lncm/save_password
 
 alpine-rpi-*-armhf.tar.gz
 


### PR DESCRIPTION
As we discussed earlier, we should enable save password for the create wallet script by default until we have a companion app to do unlocking.

Feel free to take a look at the changes, and see if you'd like to put it also in the newer branch as well, however you should be able to merge it without conflicts anyway.