### PR TITLE
Bind Tor to all interfaces

### DIFF
--- a/etc/tor/torrc
+++ b/etc/tor/torrc
@@ -1,4 +1,4 @@
-SOCKSPort 9050 # Default: Bind to localhost:9050 for local connections.
+SOCKSPort 0.0.0.0:9050 # Bind to all interfaces
 
 Log notice file /var/log/tor/notices.log
 Log notice syslog


### PR DESCRIPTION
Bind Tor to all interfaces so that services within the container can access tor.

Eventually this will go within a container