### PR TITLE
Install toml library

### DIFF
--- a/etc/init.d/lncm-post
+++ b/etc/init.d/lncm-post
@@ -39,6 +39,11 @@ start() {
     /usr/bin/pip3 install --upgrade pip && \
     /usr/bin/pip3 install docker-compose
   }
+  
+  install_toml() {
+    # Install TOTML parsing library (https://github.com/uiri/toml) so that we can write to the invoicer config files nicely
+    /usr/bin/pip3 install pip install toml
+  }
 
   usb_setup() {
     # USB storage setup
@@ -240,6 +245,7 @@ start() {
 
     move_cache
     install_compose
+    install_toml
     usb_setup
     verify_usb
     fetch_rpcauth


### PR DESCRIPTION
Install TOML library at boot so that we can create scripts to support the latest invoicer in the future.

Also we can revisit https://github.com/lncm/pi-factory/pull/163 once its done.