### PR TITLE
Enable tor + clearnet hybrid; document settings

### DIFF
--- a/home/lncm/bitcoin/bitcoin.conf
+++ b/home/lncm/bitcoin/bitcoin.conf
@@ -1,6 +1,4 @@
 # [core]
-# Set database cache size in megabytes; machines sync faster with a larger cache. Recommend setting as high as possible based upon machine's available RAM.
-dbcache=100
 # Keep at most <n> unconnectable transactions in memory.
 maxorphantx=10
 # Keep the transaction memory pool below <n> megabytes.

--- a/home/lncm/bitcoin/bitcoin.conf
+++ b/home/lncm/bitcoin/bitcoin.conf
@@ -1,5 +1,43 @@
+# [core]
+# Set database cache size in megabytes; machines sync faster with a larger cache. Recommend setting as high as possible based upon machine's available RAM.
+dbcache=100
+# Keep at most <n> unconnectable transactions in memory.
+maxorphantx=10
+# Keep the transaction memory pool below <n> megabytes.
+maxmempool=50
+# Reduce storage requirements by only storing most recent N MiB of block. This mode is incompatible with -txindex and -rescan. WARNING: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, greater than 550 = automatically prune blocks to stay under target size in MiB).
+prune=550
+
+# [network]
+# Bind to given address and always listen on it. Use [host]:port notation for IPv6.
+bind=0.0.0.0
+# Maintain at most N connections to peers.
+maxconnections=40
+# Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit.
+maxuploadtarget=5000
+# Use separate SOCKS5 proxy <ip:port> to reach peers via Tor hidden services.
+onion=127.0.0.1:9050
+
+# [zeromq]
+# Enable publishing of block hashes to <address>.
+zmqpubhashblock=0.0.0.0
+# Enable publishing of transaction hashes to <address>.
+zmqpubhashtx=0.0.0.0
+# Enable publishing of raw block hex to <address>.
+zmqpubrawblock=0.0.0.0
+# Enable publishing of raw transaction hex to <address>.
+zmqpubrawtx=0.0.0.0
+
+# [rpc]
+# Accept command line and JSON-RPC commands.
 server=1
+# Accept public REST requests.
 rest=1
+# Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. RPC clients connect using rpcuser=<USERNAM
+rpcauth=lncm:salt$hash
+# Listen for JSON-RPC connections on this port
+rpcport=8332
+# Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (
 rpcallowip=127.0.0.1
 rpcallowip=192.168.0.1/24
 rpcallowip=192.168.1.1/24
@@ -7,17 +45,6 @@ rpcallowip=10.0.0.0/8
 rpcallowip=172.16.0.0/12
 rpcallowip=172.18.0.0/16
 
-proxy=127.0.0.1:9050
-torcontrol=127.0.0.1:9051
 
-maxmempool=512
-prune=1500
-maxconnections=40
-maxuploadtarget=5000
-
-listen=1
-bind=0.0.0.0
-
-port=8333
-rpcport=8332
-GENERATEDRPCAUTH
+# Also check out Jameson Lopp's config generator:
+# https://jlopp.github.io/bitcoin-core-config-generator/

--- a/home/lncm/bitcoin/bitcoin.conf
+++ b/home/lncm/bitcoin/bitcoin.conf
@@ -18,16 +18,6 @@ maxuploadtarget=5000
 # Use separate SOCKS5 proxy <ip:port> to reach peers via Tor hidden services.
 onion=127.0.0.1:9050
 
-# [zeromq]
-# Enable publishing of block hashes to <address>.
-zmqpubhashblock=0.0.0.0
-# Enable publishing of transaction hashes to <address>.
-zmqpubhashtx=0.0.0.0
-# Enable publishing of raw block hex to <address>.
-zmqpubrawblock=0.0.0.0
-# Enable publishing of raw transaction hex to <address>.
-zmqpubrawtx=0.0.0.0
-
 # [rpc]
 # Accept command line and JSON-RPC commands.
 server=1

--- a/home/lncm/bitcoin/bitcoin.conf
+++ b/home/lncm/bitcoin/bitcoin.conf
@@ -23,11 +23,12 @@ onion=127.0.0.1:9050
 server=1
 # Accept public REST requests.
 rest=1
-# Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. RPC clients connect using rpcuser=<USERNAM
+# [rpc]
+# Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. RPC clients connect using rpcuser=<USERNAME>/rpcpassword=<PASSWORD> arguments. You can generate this value with the ./share/rpcauth/rpcauth.py script in the Bitcoin Core repository. This option can be specified multiple times.
 rpcauth=lncm:salt$hash
 # Listen for JSON-RPC connections on this port
 rpcport=8332
-# Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (
+# Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times.
 rpcallowip=127.0.0.1
 rpcallowip=192.168.0.1/24
 rpcallowip=192.168.1.1/24


### PR DESCRIPTION
- Removed default settings
- Documented all options
- Added section headers and put options in correct order
- Reduced mempool memory consumption
- Reduced prune to minimum
- Increased dbcache to speed up sync
- Switched from proxying everything via tor with `proxy=<tor-ip:port>` to `onion=<tor-ip:port>`, which is clearnet + tor hybrid by default

