### PR TITLE
Add Vagrantfile for running make-img.sh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "bento/ubuntu-18.04"
+
+  config.vm.provision "shell", inline: <<-SHELL
+  	cd /vagrant
+  	git clone https://github.com/lncm/pi-factory
+  	cd pi-factory
+  	./make_img.sh
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,10 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-18.04"
 
   config.vm.provision "shell", inline: <<-SHELL
-  	cd /vagrant
-  	git clone https://github.com/lncm/pi-factory
-  	cd pi-factory
+        cp -R /vagrant/ /home/vagrant/host
+        cd /home/vagrant/host
   	./make_img.sh
+        cp lncm-workdir/lncm-box*.zip /vagrant/
+        echo "You can find your lncm-box image in the current directory"
   SHELL
 end

--- a/make_img.sh
+++ b/make_img.sh
@@ -81,7 +81,7 @@ fetch_wifi() {
     if [ ! -f home/lncm/public_html/wifi/index.html ]; then
       echo "Fetch wifi manager"
       cd home/lncm/public_html/wifi || exit
-      wget https://raw.githubusercontent.com/lncm/iotwifi-ui/master/dist/index.html
+      wget --no-verbose https://raw.githubusercontent.com/lncm/iotwifi-ui/master/dist/index.html
     fi
 }
 
@@ -102,27 +102,27 @@ cd lncm-workdir || exit
 
 if ! [ -f ${ALP} ]; then
   echo "${ALP} not found, fetching..."
-  wget http://dl-cdn.alpinelinux.org/alpine/${REL}/releases/armhf/${ALP}
+  wget --no-verbose http://dl-cdn.alpinelinux.org/alpine/${REL}/releases/armhf/${ALP}
 fi
 
 if ! [ -f ${IOT} ]; then
   echo "${IOT} not found, fetching..."
-  wget https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${IOT}
+  wget --no-verbose https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${IOT}
 fi
 
 if ! [ -f ${FIX} ]; then
  echo "${FIX} not found, fetching..."
- wget https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${FIX}
+ wget --no-verbose https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${FIX}
 fi
 
 if ! [ -f ${CACHE} ]; then
   echo "${CACHE} not found, fetching..."
-  wget https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${CACHE}
+  wget --no-verbose https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${CACHE}
 fi
 
 if ! [ -f ${NGINX} ]; then
   echo "${NGINX} not found, fetching..."
-  wget https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${NGINX}
+  wget --no-verbose https://github.com/lncm/pi-factory/releases/download/${DOWNLOAD_VERSION}/${NGINX}
 fi
 
 echo "Create and mount 256MB image"

--- a/make_img.sh
+++ b/make_img.sh
@@ -32,9 +32,9 @@ if  [ "$(cmd_exists apk)" -eq "0" ]; then
   apk add parted zip unzip
 fi
 
-if [ "$(cmd_exists apt)" -eq "0" ]; then
+if [ "$(cmd_exists apt-get)" -eq "0" ]; then
   echo "Found Debian-based system, installing dependencies"
-  apt install -y parted zip unzip
+  apt-get install -y parted zip unzip
 fi
 
 check_deps() {


### PR DESCRIPTION
This is a basic Vagrantfile for starting Ubuntu and running make-img.sh. It auto clones the repo and runs ./make-img.sh. 

The only testing I have done is make sure the process starts successfully. 

