### PR TITLE
Update bitcoind to 0.18.0 on v0.5 branch

### DIFF
--- a/home/lncm/compose/clearnet/docker-compose.yml
+++ b/home/lncm/compose/clearnet/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8333"
       - "28332"
       - "28333"
+    entrypoint: bitcoind -zmqpubrawblock=tcp://0.0.0.0:28332 -zmqpubrawtx=tcp://0.0.0.0:28333
     networks:
       localnet:
         ipv4_address: 172.16.88.2

--- a/home/lncm/compose/clearnet/docker-compose.yml
+++ b/home/lncm/compose/clearnet/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   bitcoind:
-    image: lncm/bitcoind:0.17.1
+    image: lncm/bitcoind:0.18.0-linux-arm
     volumes:
       - /media/archive/archive/bitcoin/:/root/.bitcoin/
     ports:

--- a/home/lncm/compose/tor/docker-compose.yml
+++ b/home/lncm/compose/tor/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   bitcoind:
-    image: lncm/bitcoind:0.17.1
+    image: lncm/bitcoind:0.18.0-linux-arm
     volumes:
       - /media/archive/archive/bitcoin/:/root/.bitcoin/
     network_mode: host

--- a/home/lncm/compose/tor/docker-compose.yml
+++ b/home/lncm/compose/tor/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: lncm/bitcoind:0.18.0-linux-arm
     volumes:
       - /media/archive/archive/bitcoin/:/root/.bitcoin/
+    entrypoint: bitcoind -zmqpubrawblock=tcp://0.0.0.0:28332 -zmqpubrawtx=tcp://0.0.0.0:28333
     network_mode: host
 
   lnd:


### PR DESCRIPTION
Just built the latest bitcoind based on @meeDamian 's images (https://github.com/lncm/docker-bitcoind) which is a modification of https://github.com/lncm/docker-bitcoind/blob/master/0.17/Dockerfile to use 0.18.0 in the config.


Seems to be working on my boxes