### PR TITLE
Fix up issue where invoicer not getting proxied

### DIFF
--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -23,7 +23,7 @@ server {
         #Comment the below if running a TOR LND node
         #proxy_pass http://172.16.88.4:8080;        
         #Uncomment below and comment the above if running a TOR LND node
-        proxy_pass http://localhost:8088/api/;        
+        proxy_pass http://localhost:8088/api;        
     }
     
     # iotwifi endpoints


### PR DESCRIPTION
Fixed up issue where invoicer isn't getting proxied properly

on invoicer logs 

```
[GIN] 2019/05/27 - 09:14:01 | 404 |      118.28µs |       127.0.0.1 | POST     /api//payment
[GIN] 2019/05/27 - 09:14:21 | 404 |     108.228µs |       127.0.0.1 | GET      /api//info
```