### PR TITLE
Add in a routine to pre-generate a seed in the image with createwallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ machine-id
 # Automatic bootstrap files. For bootstrapping a wpa_supplicant and authorized_keys so that we don't have to keep doing it.
 /wpa_supplicant.automatic.conf
 /authorized_keys.automatic
-# For importing seeds
+/seed.automatic.txt
+
+# For importing seeds (don't commit these)
 home/lncm/seed.txt
 
 alpine-rpi-*-armhf.tar.gz

--- a/make_img.sh
+++ b/make_img.sh
@@ -66,6 +66,12 @@ if [ -f ./authorized_keys.automatic ]; then
     sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' ./etc/ssh/sshd_config
 fi
 
+echo 'Check for seed'
+if [ -f ./seed.automatic.txt ]; then
+    echo "Seed file exists, boostrapping the seed into the installation"
+    cp ./seed.automatic.txt ./home/lncm/seed.txt
+fi
+
 echo 'Generate fresh box.apkovl.tar.gz from source'
 sh make_apkovl.sh
 # Cleanup files we created
@@ -89,6 +95,12 @@ fetch_wifi() {
 if [ -d ./home/lncm/.ssh ]; then
     echo "Remove .ssh directory"
     rm -fr ./home/lncm/.ssh
+fi
+
+# Cleanup seed from home/lncm
+if [ -f ./home/lncm/seed.txt ]; then
+    echo "Remove seed.txt from installation so everything is equal to last commit"
+    rm ./home/lncm/seed.txt
 fi
 
 if [ -f ./etc/ssh/sshd_config.bak ]; then


### PR DESCRIPTION
Add in a routine to pre-generate a seed in the image with createwallet script

Note: that this requires a full archival node to work with this.

@AnotherDroog as this is a  proposed change to make_img.sh (and gitignore) this should also be put into the other branch too.