### PR TITLE
Modify iotwifi / nginx so that it will start up cleanly every time, Also fix up swap so it correctly starts up each time

### DIFF
--- a/etc/init.d/iotwifi
+++ b/etc/init.d/iotwifi
@@ -6,6 +6,8 @@ depend() {
 
 start() {
 	sleep 2 && \
+    docker rm iotwifi && \
+    docker stop iotwifi && \
 	docker load --input /media/mmcblk0p1/iotwifi.tar.gz && \
 	docker run --name=iotwifi -d --restart=unless-stopped --privileged --net host \
 		-v /etc/iotwifi:/cfg \

--- a/etc/init.d/nginx
+++ b/etc/init.d/nginx
@@ -8,6 +8,8 @@ depend() {
 
 start() {
 	sleep 2 && \
+    docker stop nginx && \
+    docker rm nginx && \
 	docker load --input /media/mmcblk0p1/nginx.tar.gz
 
 	# Lets see which config file to use

--- a/usr/local/sbin/lncm-usb
+++ b/usr/local/sbin/lncm-usb
@@ -153,9 +153,7 @@ setup_volatile() {
       echo '/media/volatile/volatile/swap none swap sw,pri=100 0 0' >> /etc/fstab
     fi
     # Enable swap
-    echo "Enabling swap at runlevel so it starts up"
-    cd /etc/runlevels/boot && \
-    /bin/ln -s /etc/init.d/swap swap
+    echo "Add Swap to defaults"
     # add to defaults
     /sbin/rc-update add swap
   else


### PR DESCRIPTION
Modify iotwifi / nginx so that it will start up cleanly every time (should I update this to v0.5 @AnotherDroog  ?), Also fix up swap so it correctly starts up each time (it should only be in /etc/runlevels/default not /etc/runlevels/boot)