### PR TITLE
Make the message a bit more clearer for WPA supplicant

### DIFF
--- a/etc/init.d/wpa_supplicant
+++ b/etc/init.d/wpa_supplicant
@@ -18,7 +18,7 @@ check_config_exists()
 		rm /media/mmcblk0p1/wpa_supplicant.conf
 		mount -o ro,remount /media/mmcblk0p1
 	else
-		echo "File doesnt exist"
+		echo "WPA supplicant file in FAT parition doesnt exist.. Skipping"
 	fi
 }
 


### PR DESCRIPTION
Make the message a bit clearer for WPA supplicant as "File doesn't exist" looks a little scary.

To be included in master and the v0.5.2 branches