### PR TITLE
Remove LNCM-ONLINE from boot after persistent install

### DIFF
--- a/etc/init.d/lncm
+++ b/etc/init.d/lncm
@@ -164,6 +164,7 @@ start() {
 
   disable_install() {
     echo "Deactivate LNCM installation script"
+    /sbin/rc-update del lncm-online boot || exit
     /sbin/rc-update del lncm default || exit
     /bin/rm /media/sd/etc/runlevels/default/lncm || exit
   }


### PR DESCRIPTION
Remove lncm-online from boot after persistent install is done.

After that point we probably don't need it.