### PR TITLE
Security Improvement: Make wpa_supplicant only readable by root

### DIFF
--- a/etc/init.d/wpa_supplicant
+++ b/etc/init.d/wpa_supplicant
@@ -13,7 +13,8 @@ check_config_exists()
 	if [[ -f /media/mmcblk0p1/wpa_supplicant.conf ]]; then
 		echo "File exists; copying WPA supplicant file across"
 		cp /media/mmcblk0p1/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
-		chmod 644 /etc/wpa_supplicant/wpa_supplicant.conf
+		chmod 600 /etc/wpa_supplicant/wpa_supplicant.conf
+		chown root.root /etc/wpa_supplicant/wpa_supplicant.conf
 		mount -o rw,remount /media/mmcblk0p1
 		rm /media/mmcblk0p1/wpa_supplicant.conf
 		mount -o ro,remount /media/mmcblk0p1


### PR DESCRIPTION
Have tested this change and wifi still works. So we can't leak the wifi passwords to any users (if we are using this for deployment scripts where theres a possible entry vector).

Closes #250 
